### PR TITLE
Fix embed QA extraction and add unit test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/scripts/embed_final_rfp.py
+++ b/scripts/embed_final_rfp.py
@@ -16,7 +16,7 @@ load_dotenv()
 def get_embedding(text):
     response = requests.post(
         "http://localhost:11434/api/embeddings",
-        json={"modsel": OLLAMA_EMBEDDING_MODEL, "prompt": text}
+        json={"model": OLLAMA_EMBEDDING_MODEL, "prompt": text}
     )
     return response.json()["embedding"]
 
@@ -27,12 +27,15 @@ def extract_qa_from_docx(file_path):
     paras = [p.text.strip() for p in doc.paragraphs if p.text.strip()]
     i = 0
     while i < len(paras):
-        if paras(i).endswith("?"):
+        if paras[i].endswith("?"):
             question = paras[i]
-            answer = paras[i+1] if i+1 < len(paras) else ""
+            answer = paras[i+1] if i + 1 < len(paras) else ""
             qa_pairs.append({"question": question, "answer": answer})
+            i += 2
+        else:
             i += 1
-        return qa_pairs
+
+    return qa_pairs
 
 
 def embed_and_upload_final(file_path):

--- a/tests/test_docx_extraction.py
+++ b/tests/test_docx_extraction.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from docx import Document
+
+from scripts.embed_final_rfp import extract_qa_from_docx
+
+
+def create_sample_docx(path: Path):
+    doc = Document()
+    doc.add_paragraph("What is your name?")
+    doc.add_paragraph("My name is Bot.")
+    doc.add_paragraph("What do you do?")
+    doc.add_paragraph("I automate tasks.")
+    doc.save(path)
+
+
+def test_extract_qa_from_docx(tmp_path):
+    file_path = tmp_path / "sample.docx"
+    create_sample_docx(file_path)
+    qa_pairs = extract_qa_from_docx(file_path)
+    assert qa_pairs == [
+        {"question": "What is your name?", "answer": "My name is Bot."},
+        {"question": "What do you do?", "answer": "I automate tasks."},
+    ]
+


### PR DESCRIPTION
## Summary
- fix embedding API parameter in `embed_final_rfp.py`
- correct list indexing logic and loop control
- add `pytest.ini` to restrict test discovery
- add unit test for extracting Q&A pairs from DOCX files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_6859d863378c832e91d46babe18d68bc