### PR TITLE
Use secrets in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,16 @@ rfp_automation_tool/
 ├── ui_streamlit.py  # Streamlit application
 ├── .env             # API keys and environment configs (not public)
 └── README.md        # Project documentation (this file)
+```
 
+## 🔐 Streamlit Cloud Secrets
+
+When deploying on Streamlit Cloud, set the following keys in your app's
+Secrets manager:
+
+- `OPENAI_API_KEY`
+- `QDRANT_API_KEY`
+- `QDRANT_CLUSTER_URL`
+
+These values are accessed via `st.secrets.get()` with environment variables as
+fallbacks for local development.

--- a/core/config.py
+++ b/core/config.py
@@ -1,4 +1,5 @@
 import os
+import streamlit as st
 from dotenv import load_dotenv
 from qdrant_client import QdrantClient  # <-- NEW
 
@@ -7,11 +8,11 @@ load_dotenv()
 # Model & API configuration
 OLLAMA_EMBEDDING_MODEL = "nomic-embed-text"
 OLLAMA_GENERATION_MODEL = "llama3"
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_API_KEY = st.secrets.get("OPENAI_API_KEY", os.getenv("OPENAI_API_KEY"))
 OPENAI_MODEL_NAME = "gpt-4"
 OPENAI_GENERATION_MODEL = "gpt-4-turbo"
-QDRANT_API_KEY = os.getenv("QDRANT_API_KEY")
-QDRANT_CLUSTER_URL = os.getenv("QDRANT_CLUSTER_URL")
+QDRANT_API_KEY = st.secrets.get("QDRANT_API_KEY", os.getenv("QDRANT_API_KEY"))
+QDRANT_CLUSTER_URL = st.secrets.get("QDRANT_CLUSTER_URL", os.getenv("QDRANT_CLUSTER_URL"))
 COLLECTION_NAME = "past_rfp_answers"
 REVIEW_SCORE_THRESHOLD = 0.60
 USE_OPENAI = True


### PR DESCRIPTION
## Summary
- load environment variables from Streamlit secrets when available
- document required secrets in the README

## Testing
- `python -m py_compile core/config.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d9447f68832eb7c69dd1a411496f