### PR TITLE
Add rebuild_qdrant_db utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ rfp_automation_tool/
 ├── .env             # API keys and environment configs (not public)
 └── README.md        # Project documentation (this file)
 
+After adding or updating files in `past_rfps/`, rebuild the Qdrant database by running:
+
+```bash
+python scripts/rebuild_qdrant_db.py
+```
+

--- a/core/embed.py
+++ b/core/embed.py
@@ -41,7 +41,6 @@ def embed_final_rfp(file_path):
     """
     Load a final RFP draft from DOCX, create embeddings for each paragraph, and upload to Qdrant.
     """
-    ensure_correct_collection()
 
     doc = Document(file_path)
     points = []

--- a/scripts/rebuild_qdrant_db.py
+++ b/scripts/rebuild_qdrant_db.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from core.embed import embed_final_rfp, ensure_correct_collection
+
+
+def main():
+    """Embed all past RFPs into Qdrant."""
+    ensure_correct_collection()
+
+    rfp_dir = Path("past_rfps")
+    doc_paths = sorted(rfp_dir.glob("*.docx"))
+
+    if not doc_paths:
+        print("No .docx files found in 'past_rfps/'.")
+        return
+
+    total = 0
+    for doc_path in doc_paths:
+        print(f"Embedding {doc_path.name}...")
+        embed_final_rfp(str(doc_path))
+        total += 1
+
+    print(f"Processed {total} document{'s' if total != 1 else ''}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- avoid repeatedly recreating collection in `embed_final_rfp`
- add `scripts/rebuild_qdrant_db.py` to embed all archived RFPs
- document rebuild procedure in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6859d9f22dbc832e9f42e6adbdb1e243